### PR TITLE
enable a GDRIVE_FOLDER secret to choose the google drive folder to push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       REPO_OWNER: ${{ github.repository_owner}}
       REPO_BRANCH: ${{ github.ref_name }}
       SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.SERVICE_ACCOUNT_KEY_JSON }}
+      GDRIVE_FOLDER: ${{ secrets.GDRIVE_FOLDER }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,5 @@ jobs:
         NETFILE_API_SECRET: ${{ secrets.NETFILE_API_SECRET }}
     - run: "python push_to_gdrive.py"
     - run: "python test_pull_from_gdrive.py"
-      if: ${{ env.REPO_OWNER == 'ChenglimEar' }} # Only test pull from Google Drive on developer fork
+      if: ${{ env.REPO_OWNER == 'caciviclab' }} # Only test pull from Google Drive on developer fork
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The GitHub workflow has the ability to upload redacted files in netfile_redacted
 
 2. A folder on Google Drive has to be shared with the service account.  This is done by getting the e-mail of the service account and sharing with that e-mail instead of a real person's e-mail.
 
-3. The name of the shared folder on Google Drive has to be set in a secret variable on GitHub named `GDRIVE_FOLDER`.
+3. The name of the shared folder on Google Drive has to be set in a secret variable on GitHub named `GDRIVE_FOLDER`.  This currently should be `OpenDisclosure` for the production repository and `netfile_redacted` (the default) for the development repository.
 
 3. A private key (in JSON) has to be created for the service account.  The private key (contents of JSON file) should be placed in a secret variable, `SERVICE_ACCOUNT_KEY_JSON`, on GitHub.  There's no need to remove white spaces like newlines.
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,30 @@ The GitHub workflow has the ability to upload redacted files in netfile_redacted
    - Here's some instructions on how to enable an API: https://support.google.com/googleapi/answer/6158841?hl=en.  When searching for the API to enable, simply search for `Google Drive`.
    - Here's some instructions for creating a service account: https://cloud.google.com/iam/docs/service-accounts-create#iam-service-accounts-create-console.  Create it in the same project where the Google Drive API was enabled.
 
-2. The directory on Google Drive has to be shared with the service account.  This is done by getting the e-mail of the service account and sharing with that e-mail instead of a real person's e-mail.
+2. A folder on Google Drive has to be shared with the service account.  This is done by getting the e-mail of the service account and sharing with that e-mail instead of a real person's e-mail.
 
-3. A private key (in JSON) has to be created for the service account.  The private key should be placed in an environment variable, SERVICE_ACCOUNT_KEY_JSON.  For GitHub Actions, we can simply get the value from a secret of the same name.
+3. The name of the shared folder on Google Drive has to be set in a secret variable on GitHub named `GDRIVE_FOLDER`.
 
-If SERVICE_ACCOUNT_KEY_JSON is not set, the redacted files will be copied to the repository.
+3. A private key (in JSON) has to be created for the service account.  The private key (contents of JSON file) should be placed in a secret variable, `SERVICE_ACCOUNT_KEY_JSON`, on GitHub.  There's no need to remove white spaces like newlines.
 
-A test for downloading the redacted files to a download directory is run when the workflow runs on ChenglimEar.
+If `SERVICE_ACCOUNT_KEY_JSON` is not set, the redacted files will not be copied to Google Drive.
 
-The upload and download can be tested locally by naming the key file as `.local/SERVICE_ACCOUNT_KEY_JSON.json`.  The `.local` directory is in the `.gitignore` file, so the file won't be checked in accidentally.
+When the GitHub workflow runs on `caciviclab`, it will run a test for downloading the redacted files to a download directory.  The GitHub workflow on `caciviclab` should not be configured to use the same Google Drive folder that is used in the production repository, which pulls the real data from NetFile.  This will avoid overwriting the production data.
+
+The upload and download can be tested locally by naming the key file as `.local/SERVICE_ACCOUNT_KEY_JSON.json`.  The `.local` directory is in the `.gitignore` file, so the file won't be checked in accidentally.  The `GDRIVE_FOLDER` environment variable should be set to the Google Drive folder used for local testing.
 
 ## Contributing Changes
 
-### Forking Required
+### Production Pull Required
 
-When this repository is set up to access the NetFile API, write access will be limited to protect the credentials used for NetFile.  To contribute changes, it will be necessary to fork the repository and submit a pull request from the forked repository.  Here is GitHub documentation about this process: https://docs.github.com/en/get-started/quickstart/fork-a-repo.  Only those who have access to the authoritative repository can be reviewers of the pull request.
+This repository exists in two organizations.  One is for production and one is for development.  The production repository is set up to access the NetFile API and the development repository in `caciviclab` is set up to process sample files instead of calling the API.
+
+When this repository is set up to access the NetFile API in production, write access will be limited to protect the credentials used for NetFile.  To contribute changes, it will be necessary to use the repository in `caciviclab`.  The production repository is a fork of the repository.  Here is GitHub documentation about forks: https://docs.github.com/en/get-started/quickstart/fork-a-repo.  Only those who have access to the production repository can pull the latest changes approved in the `caciviclab` repository.
+
+In short, contributions go through a two step process:
+
+1. Submit pull requests to main branch of the development repository in `caciviclab`
+2. Ask owners of the production repository to merge changes from the development repository to the production repository.
 
 ### Redaction Configuration
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,15 @@ redaction_fields:
   - filerMeta.addressList.[].zip
   - filerMeta.emailList.[].address
   - filerMeta.phoneList.[].number
-  #transactions: []
+  transactions:
+  - addresses.[].line1
+  - addresses.[].line2
+  - addresses.[].zip
+  - addresses.[].latitude
+  - addresses.[].longitude
+  - transaction.tranAdr1
+  - transaction.tranAdr2
+  - transaction.tranZip4
   #filing_activities: []
-  #filing_elements: []
-  #elections: []
+  filing_elements: []
+  elections: []

--- a/pull_and_redact_files.py
+++ b/pull_and_redact_files.py
@@ -13,9 +13,6 @@ class DataRetriever:
         if ((NETFILE_API_KEY != '') and (NETFILE_API_SECRET != '')) or os.path.exists('.env'):
             print(f'Making NetFile API calls')
             self.nf = NetFileClient(api_key='',api_secret='')
-
-        elif (REPO_OWNER != '') and (REPO_OWNER not in ['ChenglimEar']):
-            raise Exception('No NetFile credentials provided when expected')
         else:
             print(f'Simulating NetFile response since no credentials provided')
             self.nf = None

--- a/push_to_gdrive.py
+++ b/push_to_gdrive.py
@@ -2,5 +2,6 @@ import os
 from gdrive_client.GDriveCopier import GDriveCopier
 
 REPO_BRANCH = os.getenv('REPO_BRANCH','_LOCAL_')
-copier = GDriveCopier('netfile_redacted', target_branch=REPO_BRANCH)
+GDRIVE_FOLDER = os.getenv('GDRIVE_FOLDER','netfile_redacted')
+copier = GDriveCopier(GDRIVE_FOLDER, target_branch=REPO_BRANCH)
 copier.upload_from('netfile_redacted')

--- a/push_to_gdrive.py
+++ b/push_to_gdrive.py
@@ -2,6 +2,6 @@ import os
 from gdrive_client.GDriveCopier import GDriveCopier
 
 REPO_BRANCH = os.getenv('REPO_BRANCH','_LOCAL_')
-GDRIVE_FOLDER = os.getenv('GDRIVE_FOLDER','netfile_redacted')
+GDRIVE_FOLDER = os.getenv('GDRIVE_FOLDER','netfile_redacted') or 'netfile_redacted'
 copier = GDriveCopier(GDRIVE_FOLDER, target_branch=REPO_BRANCH)
 copier.upload_from('netfile_redacted')

--- a/test_pull_from_gdrive.py
+++ b/test_pull_from_gdrive.py
@@ -2,10 +2,11 @@ import os
 from gdrive_client.GDriveCopier import GDriveCopier
 
 REPO_BRANCH = os.getenv('REPO_BRANCH','_LOCAL_')
+GDRIVE_FOLDER = os.getenv('GDRIVE_FOLDER','netfile_redacted')
 
 downloads_dir = '.local/downloads'
 os.makedirs(downloads_dir, exist_ok=True)
-copier = GDriveCopier('netfile_redacted', target_branch = REPO_BRANCH)
+copier = GDriveCopier(GDRIVE_FOLDER, target_branch = REPO_BRANCH)
 copier.download_to(downloads_dir)
 print(f'Contents of downloads dir ({downloads_dir}):')
 local_files = os.listdir(downloads_dir)

--- a/test_pull_from_gdrive.py
+++ b/test_pull_from_gdrive.py
@@ -2,7 +2,7 @@ import os
 from gdrive_client.GDriveCopier import GDriveCopier
 
 REPO_BRANCH = os.getenv('REPO_BRANCH','_LOCAL_')
-GDRIVE_FOLDER = os.getenv('GDRIVE_FOLDER','netfile_redacted')
+GDRIVE_FOLDER = os.getenv('GDRIVE_FOLDER','netfile_redacted') or 'netfile_redacted'
 
 downloads_dir = '.local/downloads'
 os.makedirs(downloads_dir, exist_ok=True)


### PR DESCRIPTION
The GDRIVE_FOLDER should be set to OpenDisclosure for the production repo and it currently defaults to `netfile_redacted`, which is what it should be for the development repo.  The instructions have been updated to match the currently expected setup, including replace the `ChenglimEar` organization with `caciviclab`.

Also, I've added redaction configuration for the additional json files in netfile_samples.