### PR TITLE
Fix: NetFileClient pagination bug

### DIFF
--- a/netfile_client/NetFileClient.py
+++ b/netfile_client/NetFileClient.py
@@ -195,7 +195,7 @@ class NetFileClient:
     def fetch(self, endpoint, **kwargs):
         """ Fetch all of a particular record type """
         url = self._base_url + getattr(Routes, endpoint)
-        params = self._params
+        params = { **self._params }
         if 'params' in kwargs:
             params.update(kwargs['params'])
         res = self.session.get(url, auth=self._auth, params=params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.31.0
 gdrive-datastore==0.0.1.3
+PyYAML==6.0.1


### PR DESCRIPTION
This fixes a bug with NetFileClient where it was not starting at the first page of results when multiple endpoints were fetched in series.