### PR TITLE
Fix: get all parts of transaction records

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,9 @@
+endpoints:
+  # filers: {}
+  # filings: {}
+  transactions:
+    parts: All
+  elections: {}
 redaction_fields:
   filers:
   - addressList.[].line1
@@ -26,5 +32,5 @@ redaction_fields:
   - transaction.tranAdr2
   - transaction.tranZip4
   #filing_activities: []
-  filing_elements: []
+  # filing_elements: []
   elections: []

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 endpoints:
-  # filers: {}
-  # filings: {}
+  filers: {}
+  filings: {}
   transactions:
     parts: All
   elections: {}

--- a/netfile_client/NetFileClient.py
+++ b/netfile_client/NetFileClient.py
@@ -93,7 +93,7 @@ class NetFileClient:
 
     def fetch(self, endpoint, **kwargs):
         """ Fetch all of a particular record type """
-        self._logger.debug('Fetch got kwargs %s', kwargs)
+        self._logger.debug('fetch got kwargs %s', kwargs)
         url = self._base_url + getattr(Routes, endpoint)
         params = { **self._params }
         if 'params' in kwargs:

--- a/netfile_client/NetFileClient.py
+++ b/netfile_client/NetFileClient.py
@@ -68,6 +68,7 @@ class NetFileClient:
         self._logger.setLevel(self._log_level)
 
     def get_auth(self, env_file):
+        ''' Get key and secret from env vars or .env file '''
         key_api_key = 'NETFILE_API_KEY'
         key_api_secret = 'NETFILE_API_SECRET'
 
@@ -92,10 +93,12 @@ class NetFileClient:
 
     def fetch(self, endpoint, **kwargs):
         """ Fetch all of a particular record type """
+        self._logger.debug('Fetch got kwargs %s', kwargs)
         url = self._base_url + getattr(Routes, endpoint)
         params = { **self._params }
         if 'params' in kwargs:
             params.update(kwargs['params'])
+        self._logger.debug('Fetch %s with params %s', url, params)
         res = self.session.get(url, auth=self._auth, params=params)
         body = res.json()
         results = body['results']

--- a/pull_and_redact_files.py
+++ b/pull_and_redact_files.py
@@ -16,49 +16,59 @@ class DataRetriever:
           NETFILE_API_SECRET: the api secret for accessing NetFile API
         
         '''
-    
+
     def __init__(self, config, dest_dirpath='.local/netfile_redacted'):
         ''' Initialize with redaction configuration, destination directory and NetFile client '''
 
-        self.config = config
+        self.redaction_fields = config['redaction_fields']
+        self.endpoint_spec = config['endpoints']
         self.dest_dirpath = dest_dirpath
 
-        NETFILE_API_KEY = os.getenv('NETFILE_API_KEY','')
-        NETFILE_API_SECRET = os.getenv('NETFILE_API_SECRET','')
+        netfile_api_key = os.getenv('NETFILE_API_KEY','')
+        netfile_api_secret = os.getenv('NETFILE_API_SECRET','')
 
-        if ((NETFILE_API_KEY != '') and (NETFILE_API_SECRET != '')) or os.path.exists('.env'):
-            print(f'Making NetFile API calls')
-            self.nf = NetFileClient(api_key='',api_secret='')
+        if ((netfile_api_key != '') and (netfile_api_secret != '')) or os.path.exists('.env'):
+            print('Making NetFile API calls')
+            self.nf = NetFileClient()
         else:
-            print(f'Simulating NetFile response since no credentials provided')
+            print('Simulating NetFile response since no credentials provided')
             self.nf = None
 
         os.makedirs(self.dest_dirpath, exist_ok=True)
 
+
     def fetch_and_redact_all(self):
         ''' Get names of content to fetch from NetFile, redact and save '''
 
-        data_keys = self.config['redaction_fields'].keys()
-        for name in data_keys:
-            data = self.fetch(name)
-            self.redact(data, name)
-            with open(f'{self.dest_dirpath}/{name}.json','w') as f:
+        for name, extra_params in self.endpoint_spec.items():
+            print(f'Fetch {name} with params {extra_params}')
+            data = self.fetch(name, extra_params)
+            print(f'Got {name} of {len(data)} rows')
+
+            if name in self.redaction_fields:
+                print(f'Redact {name}')
+                self.redact(data, name)
+
+            with open(outpath := f'{self.dest_dirpath}/{name}.json','w', encoding='utf8') as f:
+                print(f'Save {name} to {outpath}')
                 json.dump(data,f,sort_keys=True,indent=1)
 
 
-    def fetch(self,name):
+    def fetch(self,name, extra_params):
         ''' Fetch a specific named content, which may be simulated if NetFile client not initialized '''
 
         if self.nf is None:
             filepath = f'netfile_samples/{name}.json'
             if os.path.exists(filepath):
-                with open(filepath,'r') as f:
+                with open(filepath,'r', encoding='utf8') as f:
                     data = json.load(f)
             else:
                 data = []
         else:
-            data = self.nf.fetch(name)
+            print(f'Pass extra_params {extra_params} to self.nf.fetch')
+            data = self.nf.fetch(name, params=extra_params)
         return data
+
 
     def redact_path(self, data, path):
         ''' Redact a specific entry in the JSON data located through a provided path 
@@ -70,15 +80,16 @@ class DataRetriever:
 
         parts = path.split('.',1)
         if len(parts) == 1:
-            if (type(data) == dict) and (path in data):
+            if isinstance(data, dict) and (path in data):
                 data[path] = '***'
         elif parts[0] == '[]':
-            if (type(data) == list):
+            if isinstance(data, list):
                 for i,v in enumerate(data):
                     self.redact_path(v, parts[1])
         else:
-            if (type(data) == dict) and (parts[0] in data):
+            if isinstance(data, dict) and (parts[0] in data):
                 self.redact_path(data[parts[0]], parts[1])
+
 
     def redact(self, data, data_key):
         ''' Apply all configured redactions for a provided content
@@ -88,16 +99,21 @@ class DataRetriever:
               data_key: the name of the content
             '''
 
-        fields_to_redact = self.config['redaction_fields'][data_key]
+        fields_to_redact = self.redaction_fields[data_key]
 
         for item in data:
             for field_path in fields_to_redact:
                 self.redact_path(item, field_path)
 
-if __name__ == '__main__':
-    with open('config.yaml', 'r') as f:
+
+def main():
+    ''' Pull and redact data based what specified in on config.yaml '''
+    with open('config.yaml', 'r', encoding='utf8') as f:
         config = yaml.safe_load(f)
 
     retriever = DataRetriever(config)
     retriever.fetch_and_redact_all()
 
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
transaction records were coming back with an empty `transaction` key because we were not passing the parameter "parts=All". This makes the DataRetriever pass extra parameters through to the NetFileClient, and adds a section "endpoints" to config.yaml where extra params can be specified. DataRetriever will load any extra params from this section of the config.